### PR TITLE
Enable GitHub Pages deployment for docs site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [master]
+    paths: ['docs/**', 'README.md']
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+title: deltasearch
+description: Embedded search for the lakehouse. ES in your pocket.
+theme: jekyll-theme-cayman

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,49 @@
+---
+layout: default
+title: Home
+---
+
+# deltasearch
+
+**Embedded search for the lakehouse. ES in your pocket.**
+
+deltasearch is a single-binary search engine that combines tantivy (Rust full-text search) with Delta Lake (versioned data lake). Point it at JSON files or blob storage and you're searching in minutes -- no cluster, no daemon, no JVM.
+
+## Getting Started
+
+- [Quickstart](getting-started/quickstart.md) -- 5-minute end-to-end tutorial
+- [Concepts](getting-started/concepts.md) -- Delta Lake, tantivy, segments, compaction
+
+## Guides
+
+- [Schema](guides/schema.md) -- Field types, inference, `--infer-from`
+- [Searching](guides/searching.md) -- Query syntax and Elasticsearch DSL
+- [Compaction](guides/compaction.md) -- L1/L2, configurable parameters, `--force-merge`
+
+## Design & Architecture
+
+- [Rust MVP Plan](plans/2026-03-23-searchdb-rust-mvp.md)
+- [Quickwit Components Research](research/2026-03-24-quickwit-components.md)
+
+### Superpowers
+
+Plans:
+
+- [Delta-as-Buffer](superpowers/plans/2026-03-24-delta-as-buffer.md)
+- [ES DSL](superpowers/plans/2026-03-24-es-dsl.md)
+- [Schema Inference](superpowers/plans/2026-03-24-schema-inference.md)
+- [Tiered Compaction](superpowers/plans/2026-03-24-tiered-compaction.md)
+- [Ingest](superpowers/plans/2026-03-25-ingest.md)
+
+Specs:
+
+- [Buffer-Promote Architecture Design](superpowers/specs/2026-03-24-buffer-promote-architecture-design.md)
+- [ES DSL Design](superpowers/specs/2026-03-24-es-dsl-design.md)
+- [Schema Inference Design](superpowers/specs/2026-03-24-schema-inference-design.md)
+- [Tiered Compaction Design](superpowers/specs/2026-03-24-tiered-compaction-design.md)
+- [Ingest Design](superpowers/specs/2026-03-25-ingest-design.md)
+
+## Links
+
+- [GitHub Repository](https://github.com/ericsson-colborn/searchdb)
+- [README](https://github.com/ericsson-colborn/searchdb#readme)


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow (`.github/workflows/docs.yml`) that deploys `docs/` to GitHub Pages on push to master when docs or README change
- Add `docs/index.md` landing page linking to all existing guides, plans, and specs
- Add `docs/_config.yml` with minimal Jekyll config (Cayman theme)

Uses GitHub's built-in Jekyll markdown rendering -- no npm, no Docusaurus, no static site generators.

Closes #27

## Test plan

- [ ] Merge to master and verify the workflow runs in the Actions tab
- [ ] Enable GitHub Pages in repo settings (Settings > Pages > Source: GitHub Actions)
- [ ] Verify the site is live at `https://ericsson-colborn.github.io/searchdb/`
- [ ] Confirm all guide links on the landing page resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)