### PR TITLE
fix: harden unwrap() calls in search result formatting

### DIFF
--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -143,7 +143,9 @@ fn print_results(results: &[searcher::SearchHit], fmt: OutputFormat) -> Result<(
             if results.is_empty() {
                 return Ok(());
             }
-            let first = results[0].doc.as_object().unwrap();
+            let first = results[0].doc.as_object().ok_or_else(|| {
+                SearchDbError::Schema("search result is not a JSON object".into())
+            })?;
             let cols: Vec<&String> = first.keys().collect();
 
             let header: Vec<String> = cols.iter().map(|c| c.to_string()).collect();
@@ -158,7 +160,9 @@ fn print_results(results: &[searcher::SearchHit], fmt: OutputFormat) -> Result<(
             );
 
             for hit in results {
-                let obj = hit.doc.as_object().unwrap();
+                let obj = hit.doc.as_object().ok_or_else(|| {
+                    SearchDbError::Schema("search result is not a JSON object".into())
+                })?;
                 let row: Vec<String> = cols
                     .iter()
                     .map(|c| match obj.get(*c) {

--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -516,7 +516,12 @@ fn doc_to_hit(
         if include_score {
             obj.insert(
                 "_score".to_string(),
-                serde_json::Value::Number(serde_json::Number::from_f64(score as f64).unwrap()),
+                serde_json::Value::Number(
+                    serde_json::Number::from_f64(score as f64).unwrap_or_else(|| {
+                        serde_json::Number::from_f64(0.0)
+                            .expect("0.0 is always a valid f64 for JSON")
+                    }),
+                ),
             );
         }
     }


### PR DESCRIPTION
## Summary
- Replace two `.as_object().unwrap()` calls in `src/commands/search.rs` (text format output) with `.ok_or_else(|| SearchDbError::Schema(...))` so malformed non-object JSON results return a descriptive error instead of panicking
- Replace `Number::from_f64(score).unwrap()` in `src/searcher.rs` with `.unwrap_or_else(|| ... 0.0)` to gracefully handle NaN/Inf scores by defaulting to 0.0

## What was changed
| File | Line(s) | Before | After |
|------|---------|--------|-------|
| `src/commands/search.rs` | 146 | `.as_object().unwrap()` | `.as_object().ok_or_else(\|\| SearchDbError::Schema(...))` |
| `src/commands/search.rs` | 161 | `.as_object().unwrap()` | `.as_object().ok_or_else(\|\| SearchDbError::Schema(...))` |
| `src/searcher.rs` | 519 | `Number::from_f64(...).unwrap()` | `.unwrap_or_else(\|\| Number::from_f64(0.0).expect(...))` |

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 292 tests pass (`cargo test`)
- [ ] Manual: run `dsrch search` with text format output and confirm results render correctly

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)