### PR TITLE
fix: handle --limit 0 without panicking

### DIFF
--- a/src/searcher.rs
+++ b/src/searcher.rs
@@ -58,6 +58,11 @@ fn execute_query(
     sort: Option<&str>,
     app_schema: &Schema,
 ) -> Result<Vec<SearchHit>> {
+    // TopDocs requires limit > 0; when no docs are needed, short-circuit.
+    if limit == 0 {
+        return Ok(vec![]);
+    }
+
     let tv_schema = index.schema();
     let reader = index
         .reader()
@@ -723,6 +728,26 @@ mod tests {
         )
         .unwrap();
         assert_eq!(offset.len(), 1);
+    }
+
+    #[test]
+    fn test_search_limit_zero_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let (index, schema, _) = setup_test_index(dir.path());
+
+        // limit=0 should return empty results without panicking
+        let zero = search(
+            &index,
+            &schema,
+            "+__present__:__all__",
+            0,
+            0,
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+        assert!(zero.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `--limit 0` with `--agg` caused a panic because `TopDocs::with_limit(0)` requires limit > 0
- Added an early return in `execute_query()` when `limit == 0`, returning an empty result set before constructing a `TopDocs` collector
- This correctly handles both cases: `--limit 0 --agg` (aggregation-only, no hits needed) and `--limit 0` without `--agg` (empty result set)

Closes #42

## Test plan

- [x] Added `test_search_limit_zero_returns_empty` unit test confirming `search()` with limit=0 returns empty vec without panicking
- [x] All 293 existing tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)